### PR TITLE
Pass CodeBlock as raw Markdown

### DIFF
--- a/md2notion/NotionPyRenderer.py
+++ b/md2notion/NotionPyRenderer.py
@@ -154,15 +154,20 @@ class NotionPyRenderer(BaseRenderer):
             "XML", 
             "YAML"
         ]
-        matchLang = next((lang for lang in notionSoLangs if re.match(re.escape(token.language), lang, re.I)), [None])
-        if not matchLang:
-            print(f"Code block language {matchLang} has no corresponding syntax in Notion.so")
+        if token.language != "":
+            matchLang = next((lang for lang in notionSoLangs if re.match(re.escape(token.language), lang, re.I)), "")
+            if not matchLang:
+                print(f"Code block language {token.language} has no corresponding syntax in Notion.so")
+        else:
+            matchLang = "Plain Text"
 
         def blockFunc(blockStr):
+            # notion-py expects raw markdown in a CodeBlock, so reinsert the codefences
+            # to ensure proper parsing
             return {
                 'type': CodeBlock,
                 'language': matchLang,
-                'title': blockStr
+                'title': f"```{matchLang}\n{blockStr}```"
             }
         return self.renderMultipleToStringAndCombine(token.children, blockFunc)
         

--- a/md2notion/NotionPyRenderer.py
+++ b/md2notion/NotionPyRenderer.py
@@ -162,15 +162,13 @@ class NotionPyRenderer(BaseRenderer):
             matchLang = "Plain Text"
 
         def blockFunc(blockStr):
-            # notion-py expects raw markdown in a CodeBlock, so reinsert the codefences
-            # to ensure proper parsing
             return {
                 'type': CodeBlock,
                 'language': matchLang,
-                'title': f"```{matchLang}\n{blockStr}```"
+                'title_plaintext': blockStr
             }
         return self.renderMultipleToStringAndCombine(token.children, blockFunc)
-        
+
     def render_thematic_break(self, token):
         return {
             'type': DividerBlock

--- a/tests/test_NotionPyRenderer.py
+++ b/tests/test_NotionPyRenderer.py
@@ -172,6 +172,45 @@ def test_nested_list():
     assert outputChild['type'] == notion.block.BulletedListBlock
     assert outputChild['title'] == 'Hewwo'
 
+def test_code_block_with_language():
+    '''it should render a fenced code block with explicit language'''
+    #arrange/act
+    raw =\
+"""\
+```python
+def get_favorite_fruit():
+    return Watermelon
+```"""
+    output = mistletoe.markdown(raw, NotionPyRenderer)
+
+    #assert
+    assert len(output) == 1
+    output = output[0]
+    assert isinstance(output, dict)
+    assert output['type'] == notion.block.CodeBlock
+    # Maintains code fencing
+    assert output['title'] == raw.replace("python", "Python")
+    assert output['language'] == 'Python'
+
+def test_code_block_without_language():
+    '''it should render a fenced code block with no language specified'''
+    #arrange/act
+    raw =\
+"""\
+```
+(f_ my_made_up_language a b)!
+```"""
+    output = mistletoe.markdown(raw, NotionPyRenderer)
+
+    #assert
+    assert len(output) == 1
+    output = output[0]
+    assert isinstance(output, dict)
+    assert output['type'] == notion.block.CodeBlock
+    # Maintains code fencing
+    assert output['title'] == raw.replace("```", "```Plain Text", 1)
+    assert output['language'] == "Plain Text"
+
 def test_big_file():
     '''it should be able to render a full Markdown file'''
     #arrange/act

--- a/tests/test_NotionPyRenderer.py
+++ b/tests/test_NotionPyRenderer.py
@@ -181,6 +181,7 @@ def test_code_block_with_language():
 def get_favorite_fruit():
     return Watermelon
 ```"""
+    expected = "def get_favorite_fruit():\n    return Watermelon\n"
     output = mistletoe.markdown(raw, NotionPyRenderer)
 
     #assert
@@ -188,8 +189,7 @@ def get_favorite_fruit():
     output = output[0]
     assert isinstance(output, dict)
     assert output['type'] == notion.block.CodeBlock
-    # Maintains code fencing
-    assert output['title'] == raw.replace("python", "Python")
+    assert output['title_plaintext'] == expected
     assert output['language'] == 'Python'
 
 def test_code_block_without_language():
@@ -200,6 +200,7 @@ def test_code_block_without_language():
 ```
 (f_ my_made_up_language a b)!
 ```"""
+    expected = "(f_ my_made_up_language a b)!\n"
     output = mistletoe.markdown(raw, NotionPyRenderer)
 
     #assert
@@ -207,8 +208,7 @@ def test_code_block_without_language():
     output = output[0]
     assert isinstance(output, dict)
     assert output['type'] == notion.block.CodeBlock
-    # Maintains code fencing
-    assert output['title'] == raw.replace("```", "```Plain Text", 1)
+    assert output['title_plaintext'] == expected
     assert output['language'] == "Plain Text"
 
 def test_big_file():


### PR DESCRIPTION
Awesome library! I seem to be having a small issue with code blocks and indentation:

```python
code = """\
```python
def hello():
    print("World!")
```"""
uploadBlock(convert(code)[0], page, "")
```

Expected: code block is created on page with `    print("World!")` indented.
Actual: code block is created on page with `print("World!")` (no ident) instead.

![image](https://user-images.githubusercontent.com/6109531/74393192-55bd5400-4dd7-11ea-838c-b6f42c710ced.png)


I did some very brief poking at `notion-py` and it seems to be that we're passing this as a `CodeBlock` which is [translated](https://github.com/jamalex/notion-py/blob/56b7a904474619cf60c4768db435c921ca18f44f/notion/block.py#L459) (inherits from `BasicBlock`) as [markdown by default](https://github.com/jamalex/notion-py/blob/56b7a904474619cf60c4768db435c921ca18f44f/notion/maps.py#L57), but since we've already stripped out the markdown portion, it looks like the parsing strips out the leading whitespace.

I'm not sure if perhaps this is an issue for `notion-py`, but here's a quick stab at a fix in this library.