### PR TITLE
Support append and update to parent page, not just child page creation.

### DIFF
--- a/md2notion/upload.py
+++ b/md2notion/upload.py
@@ -138,6 +138,7 @@ if __name__ == "__main__":
                         help='Append to page instead of creating a child page')
     parser.add_argument('--update', action='store_const', dest='mode', const='update',
                         help='Overwrites page instead of creating a child page')
+    parser.set_defaults(mode='create')
 
     args = parser.parse_args(sys.argv[1:])
 
@@ -147,22 +148,21 @@ if __name__ == "__main__":
     parentPage = client.get_block(args.page_url)
 
     for mdPath, mdFileName, mdFile in filesFromPathsUrls(args.md_path_url):
-        if args.mode == 'append':
+        if args.mode == 'create':
+            # Make a new page in Notion.so
+            pageName = mdFileName[:40]
+            page = parentPage.children.add_new(PageBlock, title=pageName)
+        else:
+            # Modify the existing page
             pageName = args.page_url
             page = parentPage
-        elif args.mode == 'update':
-            pageName = args.page_url
-            page = parentPage
+        if args.mode == 'update':
+            # First soft-remove all child nodes
             nchildren = len(page.children)
             for idx, child in enumerate(page.children):
                 pct = (idx+1)/nchildren * 100
                 print(f"\rSoft-removing existing children, {idx+1}/{nchildren} ({pct:.1f}%)", end='')
                 child.remove()
             print()
-        else:
-            # Make the new page in Notion.so
-            pageName = mdFileName[:40]
-            newPage = parentPage.children.add_new(PageBlock, title=pageName)
-            page = newPage
         print(f"Uploading {mdPath} to Notion.so at page {pageName}...")
         upload(mdFile, page)

--- a/md2notion/upload.py
+++ b/md2notion/upload.py
@@ -153,8 +153,12 @@ if __name__ == "__main__":
         elif args.mode == 'update':
             pageName = args.page_url
             uploadPage = page
-            for child in uploadPage.children:
+            nchildren = len(page.children)
+            for idx, child in enumerate(page.children):
+                pct = (idx+1)/nchildren * 100
+                print(f"\rSoft-removing existing children, {idx+1}/{nchildren} ({pct:.1f}%)", end='')
                 child.remove()
+            print()
         else:
             # Make the new page in Notion.so
             pageName = mdFileName[:40]

--- a/md2notion/upload.py
+++ b/md2notion/upload.py
@@ -144,15 +144,15 @@ if __name__ == "__main__":
     print("Initializing Notion.so client...")
     client = NotionClient(token_v2=args.token_v2)
     print("Getting target PageBlock...")
-    page = client.get_block(args.page_url)
+    parentPage = client.get_block(args.page_url)
 
     for mdPath, mdFileName, mdFile in filesFromPathsUrls(args.md_path_url):
         if args.mode == 'append':
             pageName = args.page_url
-            uploadPage = page
+            page = parentPage
         elif args.mode == 'update':
             pageName = args.page_url
-            uploadPage = page
+            page = parentPage
             nchildren = len(page.children)
             for idx, child in enumerate(page.children):
                 pct = (idx+1)/nchildren * 100
@@ -162,7 +162,7 @@ if __name__ == "__main__":
         else:
             # Make the new page in Notion.so
             pageName = mdFileName[:40]
-            newPage = page.children.add_new(PageBlock, title=pageName)
-            uploadPage = newPage
+            newPage = parentPage.children.add_new(PageBlock, title=pageName)
+            page = newPage
         print(f"Uploading {mdPath} to Notion.so at page {pageName}...")
-        upload(mdFile, uploadPage)
+        upload(mdFile, page)

--- a/md2notion/upload.py
+++ b/md2notion/upload.py
@@ -153,7 +153,8 @@ if __name__ == "__main__":
         elif args.mode == 'update':
             pageName = args.page_url
             uploadPage = page
-            # TODO first remove all the page's child nodes
+            for child in uploadPage.children:
+                child.remove()
         else:
             # Make the new page in Notion.so
             pageName = mdFileName[:40]

--- a/md2notion/upload.py
+++ b/md2notion/upload.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from urllib.parse import urlparse
 import mistletoe
 from notion.block import ImageBlock, CollectionViewBlock
 from .NotionPyRenderer import NotionPyRenderer
@@ -154,7 +155,7 @@ if __name__ == "__main__":
             page = parentPage.children.add_new(PageBlock, title=pageName)
         else:
             # Modify the existing page
-            pageName = args.page_url
+            pageName = urlparse(args.page_url).path.split('/')[-1][:-33]
             page = parentPage
         if args.mode == 'update':
             # First soft-remove all child nodes

--- a/md2notion/upload.py
+++ b/md2notion/upload.py
@@ -132,6 +132,12 @@ if __name__ == "__main__":
                         help='the url of the Notion.so page you want to upload your Markdown files to')
     parser.add_argument('md_path_url', type=str, nargs='+',
                         help='A path, glob, or url to the Markdown file you want to upload')
+    parser.add_argument('--create', action='store_const', dest='mode', const='create',
+                        help='Create a new child page (default)')
+    parser.add_argument('--append', action='store_const', dest='mode', const='append',
+                        help='Append to page instead of creating a child page')
+    parser.add_argument('--update', action='store_const', dest='mode', const='update',
+                        help='Overwrites page instead of creating a child page')
 
     args = parser.parse_args(sys.argv[1:])
 
@@ -141,8 +147,17 @@ if __name__ == "__main__":
     page = client.get_block(args.page_url)
 
     for mdPath, mdFileName, mdFile in filesFromPathsUrls(args.md_path_url):
-        # Make the new page in Notion.so
-        pageName = mdFileName[:40]
-        newPage = page.children.add_new(PageBlock, title=pageName)
+        if args.mode == 'append':
+            pageName = args.page_url
+            uploadPage = page
+        elif args.mode == 'update':
+            pageName = args.page_url
+            uploadPage = page
+            # TODO first remove all the page's child nodes
+        else:
+            # Make the new page in Notion.so
+            pageName = mdFileName[:40]
+            newPage = page.children.add_new(PageBlock, title=pageName)
+            uploadPage = newPage
         print(f"Uploading {mdPath} to Notion.so at page {pageName}...")
-        upload(mdFile, newPage)
+        upload(mdFile, uploadPage)


### PR DESCRIPTION
Fixes #9. Adds three modal options: `--append`, `--update`, and `--create` (the default and current behavior). This lets you modify the parent page instead of always creating a new child page. If you pass `--update`, the parent page's nodes will first be soft-removed so they can be replaced.