### PR TITLE
feat(images): upload images in the html blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ It provides these features over Notion.so's Markdown importer:
 * Code fences keep their original language (or as close as we can match it)
 * Code fences are formatted properly
 * Inline HTML is preserved
+* (Optionally) Upload images that are memtioned in the HTML `<img>` tags.
 * Markdown frontmatter is preserved
 * Local image references will be uploaded from relative URLs
 * Image alts are loaded as captions instead of as `TextBlock`s
@@ -33,6 +34,7 @@ There are also some configuration options:
 
 * `--clear-previous`: If a child of the note at `page-url` has the same name as what you're uploading, it will first be removed.
 * `--append`: Instead of making a new child, it will append the markdown contents to the note at `page-url`
+* `--html-img`: Upload images that are memtioned in the HTML `<img>` tags.
 
 ## Usage from script
 

--- a/md2notion/NotionPyRenderer.py
+++ b/md2notion/NotionPyRenderer.py
@@ -382,14 +382,13 @@ class NotionPyRenderer(BaseRenderer):
         content = token.content
         parser = self.__HTMLParser()
         parser.feed(content)
-        stripped_content, images = parser.get_result()
-
+        strippedContent, images = parser.get_result()
 
         ret = images
-        if stripped_content.strip() != "":
+        if strippedContent.strip() != "":
             ret.insert(0, {
                 'type': TextBlock,
-                'title': stripped_content
+                'title': strippedContent
             })
         return ret
 

--- a/md2notion/NotionPyRenderer.py
+++ b/md2notion/NotionPyRenderer.py
@@ -28,6 +28,7 @@ class NotionPyRenderer(BaseRenderer):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.render_map["HTMLBlock"] = self.render_html
+        self.render_map["HTMLSpan"] = self.render_html
 
     def render(self, token):
         """

--- a/md2notion/NotionPyRenderer.py
+++ b/md2notion/NotionPyRenderer.py
@@ -17,6 +17,17 @@ def flatten(l):
         else:
             yield el
 
+def addHtmlImgTagExtension(notionPyRendererCls):
+    """A decorator that add the image tag extension to the argument list. The
+    decorator pattern allows us to chain multiple extensions. For example, we
+    can create a renderer with extension A, B, C by writing:
+        addAExtension(addBExtension(addCExtension(notionPyRendererCls)))
+    """
+    def newNotionPyRendererCls(*extraExtensions):
+        new_extension = [HTMLBlock, HTMLSpan]
+        return notionPyRendererCls(*chain(new_extension, extraExtensions))
+    return newNotionPyRendererCls
+
 class NotionPyRenderer(BaseRenderer):
     """
     A class that will render out a Markdown file into a descriptor for upload
@@ -27,9 +38,12 @@ class NotionPyRenderer(BaseRenderer):
     object containing a descriptor for every row. This is still TODO
     """
 
-    def __init__(self, *extras):
-        extensions = [HTMLBlock, HTMLSpan]
-        super().__init__(*chain(extensions, extras))
+    def __init__(self, *extraExtensions):
+        """
+        Args:
+            *extraExtensions: a list of custom tokens to be added to the mistletoe parser.
+        """
+        super().__init__(*extraExtensions)
 
     def render(self, token):
         """

--- a/md2notion/NotionPyRenderer.py
+++ b/md2notion/NotionPyRenderer.py
@@ -1,3 +1,4 @@
+from itertools import chain
 import random
 import re
 from collections.abc import Iterable
@@ -5,7 +6,8 @@ from notion.block import CodeBlock, DividerBlock, HeaderBlock, SubheaderBlock, \
     SubsubheaderBlock, QuoteBlock, TextBlock, NumberedListBlock, \
     BulletedListBlock, ImageBlock, CollectionViewBlock, TodoBlock
 from mistletoe.base_renderer import BaseRenderer
-from mistletoe.span_token import Image, Link
+from mistletoe.block_token import HTMLBlock
+from mistletoe.span_token import Image, Link, HTMLSpan
 from html.parser import HTMLParser
 
 def flatten(l):
@@ -25,10 +27,9 @@ class NotionPyRenderer(BaseRenderer):
     object containing a descriptor for every row. This is still TODO
     """
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.render_map["HTMLBlock"] = self.render_html
-        self.render_map["HTMLSpan"] = self.render_html
+    def __init__(self, *extras):
+        extensions = [HTMLBlock, HTMLSpan]
+        super().__init__(*chain(extensions, extras))
 
     def render(self, token):
         """
@@ -361,3 +362,9 @@ class NotionPyRenderer(BaseRenderer):
             'title': content
         })
         return ret
+
+    def render_html_block(self, token):
+        return self.render_html(token) 
+
+    def render_html_span(self, token):
+        return self.render_html(token)

--- a/md2notion/upload.py
+++ b/md2notion/upload.py
@@ -116,6 +116,7 @@ def convert(mdFile, notionPyRendererCls=NotionPyRenderer):
     """
 
     mistletoe.block_token.add_token(mistletoe.block_token.HTMLBlock)
+    mistletoe.span_token.add_token(mistletoe.span_token.HTMLSpan)
     return mistletoe.markdown(mdFile, notionPyRendererCls)
 
 def upload(mdFile, notionPage, imagePathFunc=None, notionPyRendererCls=NotionPyRenderer):

--- a/md2notion/upload.py
+++ b/md2notion/upload.py
@@ -114,6 +114,8 @@ def convert(mdFile, notionPyRendererCls=NotionPyRenderer):
     @param {NotionPyRenderer} notionPyRendererCls Class inheritting from the renderer
     incase you want to render the Markdown => Notion.so differently
     """
+
+    mistletoe.block_token.add_token(mistletoe.block_token.HTMLBlock)
     return mistletoe.markdown(mdFile, notionPyRendererCls)
 
 def upload(mdFile, notionPage, imagePathFunc=None, notionPyRendererCls=NotionPyRenderer):

--- a/md2notion/upload.py
+++ b/md2notion/upload.py
@@ -115,8 +115,6 @@ def convert(mdFile, notionPyRendererCls=NotionPyRenderer):
     incase you want to render the Markdown => Notion.so differently
     """
 
-    mistletoe.block_token.add_token(mistletoe.block_token.HTMLBlock)
-    mistletoe.span_token.add_token(mistletoe.span_token.HTMLSpan)
     return mistletoe.markdown(mdFile, notionPyRendererCls)
 
 def upload(mdFile, notionPage, imagePathFunc=None, notionPyRendererCls=NotionPyRenderer):

--- a/md2notion/upload.py
+++ b/md2notion/upload.py
@@ -114,7 +114,6 @@ def convert(mdFile, notionPyRendererCls=NotionPyRenderer):
     @param {NotionPyRenderer} notionPyRendererCls Class inheritting from the renderer
     incase you want to render the Markdown => Notion.so differently
     """
-
     return mistletoe.markdown(mdFile, notionPyRendererCls)
 
 def upload(mdFile, notionPage, imagePathFunc=None, notionPyRendererCls=NotionPyRenderer):

--- a/md2notion/upload.py
+++ b/md2notion/upload.py
@@ -10,7 +10,7 @@ from urllib.parse import unquote, urlparse, ParseResult
 import mistletoe
 from notion.block import ImageBlock, CollectionViewBlock, PageBlock
 from notion.client import NotionClient
-from .NotionPyRenderer import NotionPyRenderer
+from .NotionPyRenderer import NotionPyRenderer, addHtmlImgTagExtension
 
 def relativePathForMarkdownUrl(url, mdFilePath):
     """
@@ -177,8 +177,14 @@ def cli(argv):
     parser.add_argument('--clear-previous', action='store_const', dest='mode', const='clear',
                         help='Clear a previous child page with the same name if it exists')
     parser.set_defaults(mode='create')
+    parser.add_argument('--html-img', action='store_true', default=False,
+                        help="Upload images in HTML <img> tags (disabled by default)")
 
     args = parser.parse_args(argv)
+
+    notionPyRendererCls = NotionPyRenderer
+    if args.html_img:
+        notionPyRendererCls = addHtmlImgTagExtension(notionPyRendererCls)
 
     print("Initializing Notion.so client...")
     client = NotionClient(token_v2=args.token_v2)
@@ -196,7 +202,7 @@ def cli(argv):
             # Make the new page in Notion.so
             uploadPage = page.children.add_new(PageBlock, title=mdFileName)
         print(f"Uploading {mdPath} to Notion.so at page {uploadPage.title}...")
-        upload(mdFile, uploadPage)
+        upload(mdFile, uploadPage, notionPyRendererCls)
 
 
 if __name__ == "__main__":

--- a/tests/test_NotionPyRenderer.py
+++ b/tests/test_NotionPyRenderer.py
@@ -127,7 +127,8 @@ def test_imageBlockText():
 def test_imageInHtml():
     '''it should render an image that is mentioned in the html <img> tag'''
     #arrange/act
-    output = mistletoe.markdown("head<img src=\"https://via.placeholder.com/500\" />tail", NotionPyRenderer)
+    output = mistletoe.markdown("head<img src=\"https://via.placeholder.com/500\" />tail", 
+        addHtmlImgTagExtension(NotionPyRenderer))
 
     #assert
     assert len(output) == 2
@@ -145,7 +146,7 @@ def test_imageInHtmlBlock():
 <div><img src="https://via.placeholder.com/500" alt="ImCaption"/>text in div</div>
 
 tail
-""", NotionPyRenderer)
+""", addHtmlImgTagExtension(NotionPyRenderer))
 
     #assert
     assert len(output) == 3

--- a/tests/test_NotionPyRenderer.py
+++ b/tests/test_NotionPyRenderer.py
@@ -4,8 +4,7 @@ Tests NotionPyRenderer parsing
 import re
 import mistletoe
 import notion
-from md2notion.NotionPyRenderer import NotionPyRenderer
-
+from md2notion.NotionPyRenderer import NotionPyRenderer, addHtmlImgTagExtension
 
 def test_header(capsys, headerLevel):
     '''it renders a range of headers, warns if it cant render properly'''

--- a/tests/test_NotionPyRenderer.py
+++ b/tests/test_NotionPyRenderer.py
@@ -124,6 +124,41 @@ def test_imageBlockText():
     assert isinstance(output[1], dict) #The ImageBlock can't be inline with anything else so it comes out
     assert output[1]['type'] == notion.block.ImageBlock
 
+def test_imageInHtml():
+    '''it should render an image that is mentioned in the html <img> tag'''
+    #arrange/act
+    output = mistletoe.markdown("head<img src=\"https://via.placeholder.com/500\" />tail", NotionPyRenderer)
+
+    #assert
+    assert len(output) == 2
+    assert isinstance(output[0], dict)
+    assert output[0]['type'] == notion.block.TextBlock
+    assert output[0]['title'] == "headtail" #Should extract the image
+    assert isinstance(output[1], dict) #The ImageBlock can't be inline with anything else so it comes out
+    assert output[1]['type'] == notion.block.ImageBlock
+    assert output[1]['caption'] is None
+
+def test_imageInHtmlBlock():
+    '''it should render an image that is mentioned in the html block'''
+    output = mistletoe.markdown(\
+"""
+<div><img src="https://via.placeholder.com/500" alt="ImCaption"/>text in div</div>
+
+tail
+""", NotionPyRenderer)
+
+    #assert
+    assert len(output) == 3
+    assert isinstance(output[0], dict)
+    assert output[0]['type'] == notion.block.TextBlock
+    assert output[0]['title'] == "<div>text in div</div>" #Should extract the image
+    assert isinstance(output[1], dict)
+    assert output[1]['type'] == notion.block.ImageBlock
+    assert output[1]['caption'] == "ImCaption"
+    assert isinstance(output[2], dict)
+    assert output[2]['type'] == notion.block.TextBlock
+    assert output[2]['title'] == "tail" 
+
 def test_escapeSequence():
     '''it should render out an escape sequence'''
     #arrange/act

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -311,3 +311,17 @@ def test_cli_clear_previous(mockClient, upload):
     assert args0[0].name == 'tests/TEST.md'
     assert args0[1] == mockClient.get_block.return_value.children[1]
     assert args0[1].title == 'TEST.md'
+
+@patch('md2notion.upload.upload')
+@patch('md2notion.upload.NotionClient', new_callable=MockClient)
+def test_cli_html_img_tag(mockClient, upload):
+    '''should enable the extension'''
+
+    #act
+    cli(['token_v2', 'page_url', 'tests/TEST.md', '--append', '--html-img'])
+
+    #assert
+    args0, kwargs0 = upload.call_args
+    renderer = args0[2]()
+    assert "HTMLSpan" in renderer.render_map
+    assert "HTMLBlock" in renderer.render_map


### PR DESCRIPTION
Motivation: Many markdown editors (e.g., typora, ...) use HTML to insert images so that we can set the image size easily. However, HTML in md2notion is preserved, that is, it do nothing with the images in the HTML blocks.

This PR is aims at uploading images that are mentioned in HTML blocks.