### PR TITLE
Added conversion support for markdown equations to notion format.

### DIFF
--- a/md2notion/NotionPyRenderer.py
+++ b/md2notion/NotionPyRenderer.py
@@ -28,6 +28,16 @@ def addHtmlImgTagExtension(notionPyRendererCls):
         return notionPyRendererCls(*chain(new_extension, extraExtensions))
     return newNotionPyRendererCls
 
+def addLatexExtension(notionPyRendererCls):
+    """A decorator that add the latex extensions to the argument list.
+    Markdown such as $equation$ is parsed as inline-equations and
+    $$equation$$ is parsed as an equation block.
+    """
+    def newNotionPyRendererCls(*extraExtensions):
+        new_extension = [BlockEquation, InlineEquation]
+        return notionPyRendererCls(*chain(new_extension, extraExtensions))
+    return newNotionPyRendererCls
+
 class NotionPyRenderer(BaseRenderer):
     """
     A class that will render out a Markdown file into a descriptor for upload
@@ -400,21 +410,6 @@ class NotionPyRenderer(BaseRenderer):
         assert not hasattr(token, "children")
         return self.render_html(token)
 
-
-class InlineEquation(SpanToken):
-    pattern = re.compile(r"(?<!\\|\$)(?:\\\\)*(\$+)(?!\$)(.+?)(?<!\$)\1(?!\$)", re.DOTALL)
-    parse_inner = True
-    parse_group = 2
-
-
-class BlockEquation(CodeFence):
-    pattern = re.compile(r'( {0,3})((?:\$){2,}) *(\S*)')
-
-
-class LatexNotionPyRenderer(NotionPyRenderer):
-    def __init__(self, *extraExtensions):
-        super().__init__(BlockEquation, InlineEquation, *extraExtensions)
-
     def render_block_equation(self, token):
         def blockFunc(blockStr):
             return {
@@ -425,3 +420,13 @@ class LatexNotionPyRenderer(NotionPyRenderer):
 
     def render_inline_equation(self, token):
         return self.renderMultipleToStringAndCombine(token.children, lambda s: f"$${s}$$")
+
+
+class InlineEquation(SpanToken):
+    pattern = re.compile(r"(?<!\\|\$)(?:\\\\)*(\$+)(?!\$)(.+?)(?<!\$)\1(?!\$)", re.DOTALL)
+    parse_inner = True
+    parse_group = 2
+
+
+class BlockEquation(CodeFence):
+    pattern = re.compile(r'( {0,3})((?:\$){2,}) *(\S*)')

--- a/md2notion/upload.py
+++ b/md2notion/upload.py
@@ -10,7 +10,8 @@ from urllib.parse import unquote, urlparse, ParseResult
 import mistletoe
 from notion.block import ImageBlock, CollectionViewBlock, PageBlock
 from notion.client import NotionClient
-from .NotionPyRenderer import NotionPyRenderer, addHtmlImgTagExtension
+from .NotionPyRenderer import NotionPyRenderer, addHtmlImgTagExtension, addLatexExtension
+
 
 def relativePathForMarkdownUrl(url, mdFilePath):
     """
@@ -178,12 +179,16 @@ def cli(argv):
     parser.set_defaults(mode='create')
     parser.add_argument('--html-img', action='store_true', default=False,
                         help="Upload images in HTML <img> tags (disabled by default)")
+    parser.add_argument('--latex', action='store_true', default=False,
+                        help="Support for latex inline ($..$) and block ($$..$$) equations (disabled by default)")
 
     args = parser.parse_args(argv)
 
     notionPyRendererCls = NotionPyRenderer
     if args.html_img:
         notionPyRendererCls = addHtmlImgTagExtension(notionPyRendererCls)
+    if args.latex:
+        notionPyRendererCls = addLatexExtension(notionPyRendererCls)
 
     print("Initializing Notion.so client...")
     client = NotionClient(token_v2=args.token_v2)

--- a/tests/test_NotionPyRenderer.py
+++ b/tests/test_NotionPyRenderer.py
@@ -4,7 +4,7 @@ Tests NotionPyRenderer parsing
 import re
 import mistletoe
 import notion
-from md2notion.NotionPyRenderer import NotionPyRenderer, addHtmlImgTagExtension
+from md2notion.NotionPyRenderer import NotionPyRenderer, addHtmlImgTagExtension, addLatexExtension
 
 def test_header(capsys, headerLevel):
     '''it renders a range of headers, warns if it cant render properly'''
@@ -126,7 +126,7 @@ def test_imageBlockText():
 def test_imageInHtml():
     '''it should render an image that is mentioned in the html <img> tag'''
     #arrange/act
-    output = mistletoe.markdown("head<img src=\"https://via.placeholder.com/500\" />tail", 
+    output = mistletoe.markdown("head<img src=\"https://via.placeholder.com/500\" />tail",
         addHtmlImgTagExtension(NotionPyRenderer))
 
     #assert
@@ -157,7 +157,37 @@ tail
     assert output[1]['caption'] == "ImCaption"
     assert isinstance(output[2], dict)
     assert output[2]['type'] == notion.block.TextBlock
-    assert output[2]['title'] == "tail" 
+    assert output[2]['title'] == "tail"
+
+def test_latex_inline():
+    output = mistletoe.markdown(r"""
+# Test for latex blocks
+Text before $f(x) = \sigma(w \cdot x + b)$ Text after
+""", addLatexExtension(NotionPyRenderer))
+
+    assert output[1] is not None
+    assert output[1]['type'] == notion.block.TextBlock
+    assert output[1]['title'] == r'Text before $$f(x) = \sigma(w \cdot x + b)$$ Text after'
+
+
+def test_latex_block():
+    output = mistletoe.markdown(r"""
+# Test for latex blocks
+Text before
+
+$$
+f(x) = \sigma(w \cdot x + b)
+$$
+
+Text after
+""", addLatexExtension(NotionPyRenderer))
+
+    assert output[2] is not None
+    assert output[2]['type'] == notion.block.EquationBlock
+    assert output[2]['title'] == 'f(x) = \\\\sigma(w \\\\cdot x + b)\n'
+
+def test_cli_latex_extension():
+    pass
 
 def test_escapeSequence():
     '''it should render out an escape sequence'''

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -325,3 +325,17 @@ def test_cli_html_img_tag(mockClient, upload):
     renderer = args0[3]()
     assert "HTMLSpan" in renderer.render_map
     assert "HTMLBlock" in renderer.render_map
+
+@patch('md2notion.upload.upload')
+@patch('md2notion.upload.NotionClient', new_callable=MockClient)
+def test_cli_latex(mockClient, upload):
+    '''should enable the extension'''
+
+    #act
+    cli(['token_v2', 'page_url', 'tests/TEST.md', '--append', '--latex'])
+
+    #assert
+    args0, kwargs0 = upload.call_args
+    renderer = args0[3]()
+    assert "InlineEquation" in renderer.render_map
+    assert "BlockEquation" in renderer.render_map


### PR DESCRIPTION
This PR adds an additional renderer (LatexNotionPyRenderer) which converts
* Inline Equation $y = ax + b$ is translated to $$y = ax + b$$
* Block Equation $$y = ax + b$$ is translated to notion EquationBlock.

While Inline Equation uses notion accepted format ($$) it is not yet translated to an actual inline-block. There is a PR pending in notion-py for this (https://github.com/jamalex/notion-py/pull/247).

A relevant issue for this is #20 

Example usage:
```
from md2notion.NotionPyRenderer import LatexNotionPyRenderer
from md2notion.upload import convert

mdFile1 = io.StringIO('$y = ax + b$\n$$\ny = ax + b \n $$')
mdFile1.__dict__["name"] = path
```