### PR TITLE
fix: catch 'no such image' errors from imagePathFunc

### DIFF
--- a/md2notion/upload.py
+++ b/md2notion/upload.py
@@ -83,9 +83,9 @@ def uploadBlock(blockDescriptor, blockParent, mdFilePath, imagePathFunc=None):
             imgSrc = imagePathFunc(imgRelSrc, mdFilePath)
         else:
             imgSrc = relativePathForMarkdownUrl(imgRelSrc, mdFilePath)
-            if not imgSrc:
-                print(f"ERROR: Local image '{imgRelSrc}' not found to upload. Skipping...")
-                return
+        if not imgSrc:
+            print(f"ERROR: Local image '{imgRelSrc}' not found to upload. Skipping...")
+            return
 
         print(f"Uploading file '{imgSrc}'")
         newBlock.upload_file(str(imgSrc))


### PR DESCRIPTION
By fixing the white space of the condition, it will apply to the case where a custom imagePathFunc was provided and where the default function is used.